### PR TITLE
Fix isActive field handling in authentication middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.3] - 2025-06-13
+
+### Fixed - Authentication Middleware
+
+- **User Activity Handling**: `authenticateJWT` and `optionalAuth` now preserve the `isActive` flag without forcing it to `true`, ensuring deactivated accounts are properly recognized.
+
+
 ## [1.7.2] - 2025-06-04
 
 ### Fixed - Swagger Documentation Country Relationships

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -128,7 +128,7 @@ export const authenticateJWT = async (
       provider: user.provider,
       role: user.role,
       isVerified: user.isVerified || false,
-      isActive: user.isActive || true,
+      isActive: user.isActive,
     };
 
     next();
@@ -178,7 +178,7 @@ export const optionalAuth = async (
           provider: user.provider,
           role: user.role,
           isVerified: user.isVerified || false,
-          isActive: user.isActive || true,
+          isActive: user.isActive,
         };
       }
     }


### PR DESCRIPTION
## Summary
- ensure `authenticateJWT` and `optionalAuth` preserve user `isActive` flag
- document patch release in CHANGELOG

## Testing
- `npm test` *(fails: Prisma client binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c35084c44832fa1aaeab25b39930c