### PR TITLE
Fix README cd command

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ tests/
 ```bash
 # 1. Clone the repository
 git clone git@github.com:VanGoethe/buddyPass-backend.git
-cd buddypass-backend
+cd buddyPass-backend
 
 # 2. Install dependencies with exact versions
 npm ci


### PR DESCRIPTION
## Summary
- correct the cd command in README installation instructions

## Testing
- `npm test` *(fails: cannot find name 'SubscriptionQueryOptions' and others)*

------
https://chatgpt.com/codex/tasks/task_e_684c35dd63a8832f87c1323626e61f2e