### PR TITLE
Fix auth rate limit reset test

### DIFF
--- a/tests/unit/middleware/auth.test.ts
+++ b/tests/unit/middleware/auth.test.ts
@@ -572,21 +572,23 @@ describe("Authentication Middleware", () => {
       expect(mockNext).not.toHaveBeenCalled();
     });
 
-    it("should reset attempts after window expires", (done) => {
+    it("should reset attempts after window expires", () => {
+      jest.useFakeTimers();
       const rateLimitMiddleware = authRateLimit(1, 100); // 100ms window
 
       // First request should pass
       rateLimitMiddleware(mockReq as Request, mockRes as Response, mockNext);
       expect(mockNext).toHaveBeenCalled();
 
-      // Wait for window to expire and test again
-      setTimeout(() => {
-        jest.clearAllMocks();
-        rateLimitMiddleware(mockReq as Request, mockRes as Response, mockNext);
-        expect(mockNext).toHaveBeenCalled();
-        expect(mockRes.status).not.toHaveBeenCalled();
-        done();
-      }, 150);
+      // Advance timers to simulate window expiration
+      jest.advanceTimersByTime(150);
+      jest.clearAllMocks();
+
+      rateLimitMiddleware(mockReq as Request, mockRes as Response, mockNext);
+      expect(mockNext).toHaveBeenCalled();
+      expect(mockRes.status).not.toHaveBeenCalled();
+
+      jest.useRealTimers();
     });
   });
 });


### PR DESCRIPTION
## Summary
- use Jest fake timers in the auth rate limit test

## Testing
- `npm test --silent` *(fails: Prisma Client could not locate the Query Engine)*

------
https://chatgpt.com/codex/tasks/task_e_684c3656d538832f9f6d2742edcaf2b2